### PR TITLE
feat / breakpoint as number

### DIFF
--- a/src/scss/02-tools/_m-breakpoint.scss
+++ b/src/scss/02-tools/_m-breakpoint.scss
@@ -18,20 +18,24 @@
 
 @mixin breakpoints($breakpoint, $min-or-max-or-breakpoint: min) {
     $font-size: 16px; // don't use em function whitout param, $font-size-base can be modified
+    $current-breakpoint: map.get($breakpoints, $breakpoint);
+    @if (type-of($breakpoint) == "number") {
+        $current-breakpoint: $breakpoint;
+    }
 
     @if (type-of(map.get($breakpoints, $min-or-max-or-breakpoint)) == "number") {
 
-        @media screen and (min-width: em(map.get($breakpoints, $breakpoint), $font-size)) and (max-width: em(map.get($breakpoints, $min-or-max-or-breakpoint) - 1, $font-size)) {
+        @media screen and (min-width: em($current-breakpoint, $font-size)) and (max-width: em(map.get($breakpoints, $min-or-max-or-breakpoint) - 1, $font-size)) {
             @content;
         }
     } @else if ($min-or-max-or-breakpoint == max) {
 
-        @media screen and (max-width: em(map.get($breakpoints, $breakpoint) - 1, $font-size)) {
+        @media screen and (max-width: em($current-breakpoint - 1, $font-size)) {
             @content;
         }
     } @else {
 
-        @media screen and (min-width: em(map.get($breakpoints, $breakpoint), $font-size)) {
+        @media screen and (min-width: em($current-breakpoint, $font-size)) {
             @content;
         }
     }


### PR DESCRIPTION
Ho modificato il mixin breakpoints in modo da poter usare un valore numerico oltre che un breakpoint mappato.
Mi risulta comodo quando ci sono casi particolari in cui ho bisogno di un breakpoint ad un valore specifico.
`@include breakpoints(md) { ... }`
`@include breakpoints(1500) { ... }`
`@include breakpoints(1500, max) { ... }`